### PR TITLE
#7 Added Paging to the SPARQL-Queries to try to improve the performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,14 +20,8 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.2.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.2.0</version>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/backend/TopicManagerImplIT.java
+++ b/src/test/java/backend/TopicManagerImplIT.java
@@ -30,9 +30,9 @@ class TopicManagerImplIT {
             List.of("uri", "sample_property", "label").stream().map((Function<String, Object>) resultBinding::contains))
             .as("each result set must contain the variables 'new_word' and 'sample_property'")
             .containsOnly(true))
-        .as("some proposal must have label '2014-15 DEL season' and corresponding URI")
+        .as("some proposal must have label '2010_IIHF_World_Championship' and corresponding URI")
         .anySatisfy(resultBinding -> {
-          final String proposal = "2014–15_DEL_season";
+          final String proposal = "2010_IIHF_World_Championship";
           assertThat(resultBinding.get("uri").toString().contains(proposal))
               .isTrue();
           assertThat(resultBinding.get("label").asLiteral().getString()).isEqualTo(proposal.replace("_", " "));


### PR DESCRIPTION
-  Implemented paging for the query that suggests new resources:
Pages of a defined size are requested and processed, until enough resources have been found. Thus the app does not request all available data, but only about as much as is required. 
The page size can be changed in code.

- Removed the DESCRIBE query when adding a new topic to the memory model, as it had an extremely poor performance. Now the CONSTRUCT query is directly send to the SPARQL-Endpoint, so that only the required information is returned.

All queries _should_ still do the same as before.

