### PR TITLE
#3 decrease redundancy

### DIFF
--- a/src/main/java/backend/TopicManagerImpl.java
+++ b/src/main/java/backend/TopicManagerImpl.java
@@ -24,7 +24,8 @@ public class TopicManagerImpl implements TopicManager {
   private static final String DBPEDIA_SPARQL_ENDPOINT = "http://dbpedia.org/sparql";
   private static final String SPARQL_PREFIXES = "PREFIX dbr: <" + RESOURCE_URI + "> "
       + "PREFIX dbo: <" + ONTOLOGY_URI + "> "
-      + "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> ";
+      + "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> "
+      + "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>";
   private static final String MEANINGLESS_PROPERTY = "dbo:wikiPageWikiLink";
 
 
@@ -53,7 +54,8 @@ public class TopicManagerImpl implements TopicManager {
   public void addResourceToTopics(final String resourceUrl) throws InvalidUriInputException {
     final Query constructSubjectQuery = QueryFactory.create(SPARQL_PREFIXES
             + "CONSTRUCT { <" + resourceUrl + "> ?p ?o }"
-            + "WHERE { <" + resourceUrl + "> ?p ?o "
+            + "WHERE { <" + resourceUrl + "> ?p ?o . "
+            + "        ?o rdf:type ?type "
             + "FILTER ("
             + "  ?p != " + MEANINGLESS_PROPERTY 
             + "  && "
@@ -62,7 +64,8 @@ public class TopicManagerImpl implements TopicManager {
             );
     final Query constructObjectQuery = QueryFactory.create(SPARQL_PREFIXES
             + "CONSTRUCT { ?s ?p <" + resourceUrl + "> } "
-            + "WHERE { ?s ?p <" + resourceUrl + ">"
+            + "WHERE { ?s ?p <" + resourceUrl + "> . "
+            + "        ?s rdf:type ?type "
             + "FILTER ("
             + "  ?p != " + MEANINGLESS_PROPERTY 
             + "    &&"

--- a/src/test/java/backend/TopicManagerImplIT.java
+++ b/src/test/java/backend/TopicManagerImplIT.java
@@ -49,7 +49,7 @@ class TopicManagerImplIT {
     // then
     assertThat(cut)
         .as("Memory model must be filled.")
-        .satisfies(x -> assertThat(x.memoryModel.size()).isEqualTo(598))
+        .satisfies(x -> assertThat(x.memoryModel.size()).isEqualTo(577))
         .as("New uri must be added to previous resources.")
         .satisfies(x -> assertThat(x.previousResources).contains(uri))
         .as("Current topic must be set to new uri.")

--- a/src/test/java/backend/TopicManagerImplIT.java
+++ b/src/test/java/backend/TopicManagerImplIT.java
@@ -49,7 +49,7 @@ class TopicManagerImplIT {
     // then
     assertThat(cut)
         .as("Memory model must be filled.")
-        .satisfies(x -> assertThat(x.memoryModel.size()).isEqualTo(577))
+        .satisfies(x -> assertThat(x.memoryModel.size()).isEqualTo(10147))
         .as("New uri must be added to previous resources.")
         .satisfies(x -> assertThat(x.previousResources).contains(uri))
         .as("Current topic must be set to new uri.")


### PR DESCRIPTION
I finally managed to decrease the redundancy by including type information in the memory model. `getSuggestionsForCurrentTopic()` now takes into account the whole set of types in the proposals. Only topics that have at least one type that is not yet among the types of the other proposals are now added to the list of suggested topics.